### PR TITLE
Update Dependencies and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+#OSX
+.DS_Store
+.localized
+
 # IntelliJ
 .idea/
 
@@ -66,4 +70,3 @@ docs/_build/
 
 # PyBuilder
 target/
-

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Users can override either of the configured values on the command line.
 
 ## Installation
 * *Note: Python 2.7.10 is the minimal version supported*
-* *Note: All platforms have been tested with both Python 2.7 and 3.4*
+* *Note: All platforms have been tested with both Python 2.7 and 3.5*
 
 ### OSX
-* *Note: If you are using El Capitan, refer to the subsequent OSX section*
+* *Note: If you are using El Capitan or Sierra, refer to the subsequent OSX section*
 
 0. sudo easy_install pip
 1. sudo pip install kerb-sts
@@ -47,6 +47,12 @@ to follow these instructions which leverage virtual environments.*
 3. sudo pip install kerb-sts --ignore-installed six
 4. deactivate
 5. sudo ln -s ~/kerb-sts/bin/kerb-sts /usr/local/bin/kerb-sts
+
+### MacOS Sierra
+0. You will need to update your version of Python to 2.7.12+; Homebrew is the easiest method.
+1. You will also need to install/update the XCODE Development Extensions
+  1a. sudo xcode-select install
+2. You can then just run sudo pip install kerb-sts
 
 ### Windows
 0. Install [Python] (https://www.python.org/downloads/)

--- a/setup.py
+++ b/setup.py
@@ -42,15 +42,12 @@ setup(
     ],
     install_requires=[
         'beautifulsoup4>=4.4.1',
-        'boto>=2.43.0',
-        'botocore>=1.4.80',
-        'requests>=2.12.3',
-        'requests-ntlm>=0.3.0',
-        'ntlm-auth==1.0.2',
-        'requests-kerberos>=0.11.0',
-        'configparser==3.5.0'
+        'boto>=2.39.0',
+        'requests-ntlm>=0.2.0',
+        'requests-kerberos==0.8.0',
+        'configparser==3.5.0b2'
     ],
-
+    
     entry_points={
         'console_scripts': [
             'kerb-sts=kerb_sts.__main__:main'

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     install_requires=[
         'beautifulsoup4>=4.4.1',
         'boto>=2.43.0',
-        'boto3>=1.4.3',
+        'boto3>=1.4.2',
         'botocore>=1.4.80',
         'requests>=2.12.3',
         'requests-ntlm>=0.3.0',

--- a/setup.py
+++ b/setup.py
@@ -42,12 +42,16 @@ setup(
     ],
     install_requires=[
         'beautifulsoup4>=4.4.1',
-        'boto>=2.39.0',
-        'requests-ntlm>=0.2.0',
-        'requests-kerberos==0.8.0',
-        'configparser==3.5.0b2'
+        'boto>=2.43.0',
+        'boto3>=1.4.3',
+        'botocore>=1.4.80',
+        'requests>=2.12.3',
+        'requests-ntlm>=0.3.0',
+        'ntlm-auth==1.0.2',
+        'requests-kerberos>=0.11.0',
+        'configparser==3.5.0'
     ],
-    
+
     entry_points={
         'console_scripts': [
             'kerb-sts=kerb_sts.__main__:main'

--- a/setup.py
+++ b/setup.py
@@ -42,12 +42,15 @@ setup(
     ],
     install_requires=[
         'beautifulsoup4>=4.4.1',
-        'boto>=2.39.0',
-        'requests-ntlm>=0.2.0',
-        'requests-kerberos==0.8.0',
-        'configparser==3.5.0b2'
+        'boto>=2.43.0',
+        'botocore>=1.4.80',
+        'requests>=2.12.3',
+        'requests-ntlm>=0.3.0',
+        'ntlm-auth==1.0.2',
+        'requests-kerberos>=0.11.0',
+        'configparser==3.5.0'
     ],
-    
+
     entry_points={
         'console_scripts': [
             'kerb-sts=kerb_sts.__main__:main'


### PR DESCRIPTION
Update Dependencies due to CVE Patches; along with better Windows Support with the latest requests-kerberos package.
Update README to include addendum on MacOS Sierra, and that Kerb-Sts works with Python3.5.
Add OSX Files .DS_Store and .localized to the .gitignore file.