### PR TITLE
Make codebase less specific to AD FS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 - '3.4'
 - '3.5'
 install:
-  - pip install --upgrade pip setuptools
+  - pip install --upgrade setuptools
   - python setup.py install
 script: nosetests
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ python:
 - '3.3'
 - '3.4'
 - '3.5'
-install: python setup.py install
+install:
+  - pip install --upgrade "setuptools<40.0.0"
+  - python setup.py install
 script: nosetests
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ python:
 - '3.3'
 - '3.4'
 - '3.5'
-install: python setup.py install
+install:
+  - pip install --upgrade pip setuptools
+  - python setup.py install
 script: nosetests
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 - '3.4'
 - '3.5'
 install:
-  - pip install --upgrade setuptools
+  - pip install --upgrade "setuptools<40.0.0"
   - python setup.py install
 script: nosetests
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ python:
 - '3.3'
 - '3.4'
 - '3.5'
-install:
-  - pip install --upgrade "setuptools<40.0.0"
-  - python setup.py install
+install: python setup.py install
 script: nosetests
 deploy:
   provider: pypi

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ authenticate using NTLM with their username and password or with a Kerberos keyt
 Kerb-STS looks for configuration in the ~/.kerb-sts/config.json file. This file contains the following fields: 
 
 Field | Required? | Description
---- |:--- |:---
+:--- |:--- |:---
 idp_url | Yes | URL where the SAML authentication requests are sent
 region | Yes | Region for AWS credentials
 kerb_domain | No | Domain name used for the Kerberos GSS exchange. This is set to the domain name of `idp_url` by default

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Kerb-STS looks for configuration in the ~/.kerb-sts/config.json file. This file 
 Field | Required? | Description
 :--- |:--- |:---
 idp_url | Yes | URL where the SAML authentication requests are sent
+adfs_url | No | **deprecated** URL where the SAML authentication requests are sent
 region | Yes | Region for AWS credentials
 kerb_domain | No | Domain name used for the Kerberos GSS exchange. This is set to the domain name of `idp_url` by default
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,31 @@
 # AWS KERBEROS STS
-Based on the ADSF-CLI script  [originally posted by Quint Van Deman] (https://blogs.aws.amazon.com/security/post/Tx1LDN0UBGJJ26Q/How-to-Implement-Federated-API-and-CLI-Access-Using-SAML-2-0-and-AD-FS)
+Based on the ADSF-CLI script  [originally posted by Quint Van Deman] (https://blogs.aws.amazon.com/security/post/Tx1LDN0UBGJJ26Q/How-to-Implement-Federated-API-and-CLI-Access-Using-SAML-2-0-and-AD-FS).
 
 ## Overview
-This script provides a seamless mechanism for federating the AWS CLI. When
-properly configured this script allows a user to get a short lived (1 hour) set of
-credentials for each authorized role.
+This script provides a seamless mechanism for federating the AWS CLI. When properly configured, this script allows a user to get a short lived (1 hour) set of credentials for each authorized role.
 
-The script leverages Kerberos and ADFS to avoid any need for the user to enter
-a AD domain password or provide AWS credentials. However, users can also
+The script leverages Kerberos and a [SAML-compatible IdP](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml.html) to avoid any need for the user to enter
+an AD domain password, or provide AWS credentials. However, users can also
 authenticate using NTLM with their username and password or with a Kerberos keytab.
 
 ## Configuration
-Kerb-STS looks for configuration in the ~/.kerb-sts/config.json file. This file contains
-the URL of the ADFS AWS login page and the default region. Users can generate this file with Kerb-STS:
+Kerb-STS looks for configuration in the ~/.kerb-sts/config.json file. This file contains the following fields: 
+| Field | Required? | Description |
+| --- | --- | --- |
+| idp_url | Yes | URL where the SAML authentication requests are sent. |
+| region | Yes | Region for AWS credentials. |
+| kerb_domain | No | Domain name used for the Kerberos GSS exchange. This is set to the domain name of `idp_url` by default. |
+
+Users can generate this file with Kerb-STS:
 ```
 kerb-sts --configure
 ```
 This will prompt the user for those values and then serialize the configuration. Users
-can also manually create the configuration file which should look like the following:
+can also manually create the configuration file. A sample for AD FS is demonstrated below:
 ```
 {
   "region": "us-east-1",
-  "adfs_url": "https://sample.domain.com/adfs/ls/IdpInitiatedSignOn.aspx?loginToRp=urn:amazon:webservices"
+  "idp_url": "https://sample.domain.com/adfs/ls/IdpInitiatedSignOn.aspx?loginToRp=urn:amazon:webservices"
 }
 ```
 Users can override either of the configured values on the command line.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ authenticate using NTLM with their username and password or with a Kerberos keyt
 
 ## Configuration
 Kerb-STS looks for configuration in the ~/.kerb-sts/config.json file. This file contains the following fields: 
-| Field | Required? | Description |
-| --- | --- | --- |
-| idp_url | Yes | URL where the SAML authentication requests are sent. |
-| region | Yes | Region for AWS credentials. |
-| kerb_domain | No | Domain name used for the Kerberos GSS exchange. This is set to the domain name of `idp_url` by default. |
+
+Field | Required? | Description
+--- |:--- |:---
+idp_url | Yes | URL where the SAML authentication requests are sent
+region | Yes | Region for AWS credentials
+kerb_domain | No | Domain name used for the Kerberos GSS exchange. This is set to the domain name of `idp_url` by default
 
 Users can generate this file with Kerb-STS:
 ```

--- a/kerb_sts/__main__.py
+++ b/kerb_sts/__main__.py
@@ -105,13 +105,12 @@ def _configure():
     Generates a configuration file for subsequent runs to consume.
     """
     idp_url = input(
-        "IdP AWS sign in URL i.e.: "
-        "https://yourdomain.com/adfs/ls/IdpInitiatedSignOn.aspx?loginToRp=urn:amazon:webservices): "
+        "IdP AWS sign in URL: "
     )
     kerb_hostname = input(
-        "Kerberos hostname. Defaults to domain of IdP URL: "
+        "Kerberos hostname (default: IdP AWS sign in URL domain): "
     )
-    region = input("AWS region. Defaults to {}: ".format(DEFAULT_REGION))
+    region = input("AWS region (default: {}): ".format(DEFAULT_REGION))
     if region == '':
         region = DEFAULT_REGION
 

--- a/kerb_sts/auth.py
+++ b/kerb_sts/auth.py
@@ -40,7 +40,8 @@ class KerberosAuthenticator(Authenticator):
     authenticate a user who's machine is logged into to the Domain.
     """
 
-    def __init__(self):
+    def __init__(self, kerb_hostname=None):
+        self.kerb_hostname = kerb_hostname if kerb_hostname else None
         # Windows does not have support for `klist`. Assume
         # Windows users have a valid Kerberos ticket.
         if os.name != 'nt':
@@ -54,7 +55,7 @@ class KerberosAuthenticator(Authenticator):
                     raise Exception("failed to generate a kerberos ticket")
 
     def get_auth_handler(self, session):
-        return HTTPKerberosAuth(mutual_authentication=OPTIONAL)
+        return HTTPKerberosAuth(mutual_authentication=OPTIONAL, hostname_override=self.kerb_hostname)
 
     @staticmethod
     def get_auth_type():

--- a/kerb_sts/awsrole.py
+++ b/kerb_sts/awsrole.py
@@ -26,7 +26,7 @@ class AWSRole:
     def __init__(self, aws_role):
         """
         Create a new Role object and parse the specified role into is parts.
-        :param aws_role: the text from the ADFS login page
+        :param aws_role: the text from the IdP login page
         """
         if AWSRole.is_valid(aws_role):
             self._parse(aws_role)

--- a/kerb_sts/config.py
+++ b/kerb_sts/config.py
@@ -32,11 +32,13 @@ class Config:
     The Config object stores connection configuration for
     the tool.
     """
-    ADFS_URL_KEY = 'adfs_url'
+    IDP_URL_KEY = 'idp_url'
+    KERB_HOSTNAME_KEY = 'kerb_hostname'
     REGION_KEY = 'region'
 
-    def __init__(self, adfs_url, region):
-        self.adfs_url = adfs_url
+    def __init__(self, idp_url, kerb_hostname, region):
+        self.idp_url = idp_url
+        self.kerb_hostname = kerb_hostname
         self.region = region
 
     def save(self, filename=_get_default_config_filename()):
@@ -47,7 +49,11 @@ class Config:
         if not os.path.exists(os.path.dirname(filename)):
             os.makedirs(os.path.dirname(filename))
 
-        dictionary = {Config.ADFS_URL_KEY: self.adfs_url, Config.REGION_KEY: self.region}
+        dictionary = {
+            Config.IDP_URL_KEY: self.idp_url,
+            Config.KERB_HOSTNAME_KEY: self.kerb_hostname,
+            Config.REGION_KEY: self.region
+        }
         with open(filename, 'w') as f:
             json.dump(dictionary, f)
             logging.info("config file saved to {}".format(filename))
@@ -57,7 +63,7 @@ class Config:
         Validates that the Config object is valid (non-null non-empty values).
         :return: True if the Config is valid
         """
-        return (self.adfs_url is not None and self.adfs_url is not '' and
+        return (self.idp_url is not None and self.idp_url is not '' and
                 self.region is not None and self.region is not '')
 
     @staticmethod
@@ -68,13 +74,16 @@ class Config:
         :param filename: the path to the config file
         :return: a Config object constructed from the filename's contents
         """
-        config = Config(adfs_url='', region='')
+        config = Config(idp_url='', kerb_hostname='', region='')
         try:
             with open(filename) as f:
                 config_json = json.loads(f.read())
                 if config_json:
-                    if Config.ADFS_URL_KEY in config_json:
-                        config.adfs_url = str(config_json[Config.ADFS_URL_KEY])
+                    if Config.IDP_URL_KEY in config_json:
+                        config.idp_url = str(config_json[Config.IDP_URL_KEY])
+
+                    if Config.KERB_HOSTNAME_KEY in config_json:
+                        config.kerb_hostname = str(config_json[Config.KERB_HOSTNAME_KEY])
 
                     if Config.REGION_KEY in config_json:
                         config.region = str(config_json[Config.REGION_KEY])

--- a/kerb_sts/config.py
+++ b/kerb_sts/config.py
@@ -33,6 +33,7 @@ class Config:
     the tool.
     """
     IDP_URL_KEY = 'idp_url'
+    ADFS_URL_KEY = 'adfs_url'
     KERB_HOSTNAME_KEY = 'kerb_hostname'
     REGION_KEY = 'region'
 
@@ -81,6 +82,8 @@ class Config:
                 if config_json:
                     if Config.IDP_URL_KEY in config_json:
                         config.idp_url = str(config_json[Config.IDP_URL_KEY])
+                    elif Config.ADFS_URL_KEY in config_json:
+                        config.idp_url = str(config_json[Config.ADFS_URL_KEY])
 
                     if Config.KERB_HOSTNAME_KEY in config_json:
                         config.kerb_hostname = str(config_json[Config.KERB_HOSTNAME_KEY])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-cryptography>=1.3, <2; python_version=="3.3"
-setuptools<40.0.0; python_version=="3.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+cryptography>=1.3, <2; python_version=="3.3"
+setuptools<40.0.0; python_version=="3.3"

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ setup(
         'requests>=2.12.3',
         'requests-kerberos>=0.11.0',
         'requests-ntlm>=0.3.0',
-        'six>=1.10.0'
+        'six>=1.10.0',
+        'cryptography>=1.3,<2;python_version=="3.3"'
     ],
 
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'configparser==3.5.0',
         'ntlm-auth==1.0.2',
         'requests>=2.12.3',
-        'requests-kerberos>=0.11.0',
+        'requests-kerberos==0.11.0',
         'requests-ntlm>=0.3.0',
         'six>=1.10.0'
     ],

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'configparser==3.5.0',
         'ntlm-auth==1.0.2',
         'requests>=2.12.3',
-        'requests-kerberos==0.11.0',
+        'requests-kerberos>=0.11.0',
         'requests-ntlm>=0.3.0',
         'six>=1.10.0'
     ],


### PR DESCRIPTION
This change set removes most wording around "AD FS" as this project will work with other IdPs. Additionally, more configuration is allowed around setting the kerberos domain name override. This is useful when your IdP URL doesn't match the kerberos domain.