### PR TITLE
Remove support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
 - '2.7'
-- '3.3'
 - '3.4'
 - '3.5'
 install:

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
 
     classifiers=[
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
@@ -49,8 +48,7 @@ setup(
         'requests>=2.12.3',
         'requests-kerberos>=0.11.0',
         'requests-ntlm>=0.3.0',
-        'six>=1.10.0',
-        'cryptography>=1.3,<2;python_version=="3.3"'
+        'six>=1.10.0'
     ],
 
     entry_points={


### PR DESCRIPTION
`requests-kerberos` requires a version of `cryptography` with a security vulnerability when using Python 3.3.