### PR TITLE
Handle OneLogin Active Directory Connector form

### DIFF
--- a/kerb_sts/__main__.py
+++ b/kerb_sts/__main__.py
@@ -65,8 +65,8 @@ def _get_options():
                         dest='configure', action='store_true', default=False)
     parser.add_argument('--daemon', help="Run as a daemon. This will auto-renew credentials every half hour",
                         dest='daemon', action='store_true', default=False)
-    parser.add_argument('-r', '--default_role', help="Name of the Role to use as the default",
-                        dest='default_role', default=None)
+    parser.add_argument('-r', '--default_profile', help="Name of the Profile to use as the default",
+                        dest='default_profile', default=None)
     parser.add_argument('-d', '--domain', help="AD Domain if using a Kerberos keytab or NTLM auth. Requires a username and password/keytab",
                         dest='domain', default=None)
     parser.add_argument('--keytab', help="The Kerberos keytab file. Requires a username and domain",
@@ -204,13 +204,13 @@ def _generate_tokens(options, config, authenticator):
     logging.info("region: {}".format(config.region))
     logging.info("url: {}".format(config.idp_url))
     logging.info("credentials file: {}".format(options.credentials_file))
-    if options.default_role:
-        logging.info("default role: {}".format(options.default_role))
+    if options.default_profile:
+        logging.info("default profile: {}".format(options.default_profile))
     logging.info("auth type: {}".format(authenticator.get_auth_type()))
 
     h = KerberosHandler()
     h.handle_sts_by_kerberos(config.region, config.idp_url, options.credentials_file, options.config_file,
-                             options.default_role, options.list, authenticator)
+                             options.default_profile, options.list, authenticator)
     logging.info("--------------------------------")
 
 

--- a/kerb_sts/handler.py
+++ b/kerb_sts/handler.py
@@ -43,14 +43,14 @@ class KerberosHandler:
         self.ssl_verification = True
 
     def handle_sts_by_kerberos(self, region, url, credentials_filename, config_filename,
-                               default_role, list_only, authenticator):
+                               default_profile, list_only, authenticator):
         """
         Entry point for generating a set of temporary tokens from AWS.
         :param region: The AWS region tokens are being requested for
         :param url: The URL of the IdP endpoint to auth against
         :param credentials_filename: Where should the tokens be written to
         :param config_filename: Where should the region/format be written to
-        :param default_role: Which IAM role should be set as the default in the config file
+        :param default_profile: Which profile should be set as the default in the config file
         :param list_only: If set, the IAM roles available will just be printed instead of assumed
         :param authenticator: the Authenticator
         """
@@ -102,9 +102,9 @@ class KerberosHandler:
                 break
 
         # We got a successful response from the IdP. Parse the assertion and pass it to AWS
-        self._handle_sts_from_response(response, region, credentials_filename, config_filename, default_role, list_only)
+        self._handle_sts_from_response(response, region, credentials_filename, config_filename, default_profile, list_only)
 
-    def _handle_sts_from_response(self, response, region, credentials_filename, config_filename, default_role, list_only):
+    def _handle_sts_from_response(self, response, region, credentials_filename, config_filename, default_profile, list_only):
         """
         Takes a successful SAML response, parses it for valid AWS IAM roles, and then reaches out to
         AWS and requests temporary tokens for each of the IAM roles.
@@ -112,7 +112,7 @@ class KerberosHandler:
         :param region: The AWS region tokens are being requested for
         :param credentials_filename: Where should the region/format be written to
         :param config_filename: Where should the tokens be written to
-        :param default_role: Which IAM role should be as as the default in the config file
+        :param default_profile: Which profile should be as as the default in the config file
         :param list_only: If set, the IAM roles available will just be printed instead of assumed
         """
 
@@ -124,6 +124,7 @@ class KerberosHandler:
         for inputtag in soup.find_all('input'):
             if inputtag.get('name') == 'SAMLResponse':
                 assertion = inputtag.get('value')
+                break
 
         if not assertion:
             raise Exception("did not get a valid SAML response. response was:\n%s" % response.text)
@@ -152,39 +153,39 @@ class KerberosHandler:
 
         # If the user supplied to a default role make sure
         # that role is available to them.
-        if default_role is not None:
-            found_default_role = False
+        if default_profile is not None:
+            found_default_profile = False
             for aws_role in aws_roles:
-                name = AWSRole(aws_role).name
-                if name == default_role:
-                    found_default_role = True
+                profile = AWSRole(aws_role).profile
+                if profile == default_profile:
+                    found_default_profile = True
                     break
-            if not found_default_role:
-                raise Exception("provided default role not found in list of available roles")
+            if not found_default_profile:
+                raise Exception("provided default profile not found in list of available roles")
 
         # Go through each of the available roles and
         # attempt to get temporary tokens for each
         for aws_role in aws_roles:
-            profile = AWSRole(aws_role).name
+            profile = AWSRole(aws_role).profile
 
             if list_only:
-                logging.info("role: {}".format(profile))
+                logging.info("profile: {}".format(profile))
             else:
                 token = self._bind_assertion_to_role(assertion, aws_role, profile,
-                                                     region, credentials_filename, config_filename, default_role)
+                                                     region, credentials_filename, config_filename, default_profile)
 
                 if not token:
                     raise Exception("did not receive a valid token from aws.")
 
                 expires_utc = token.credentials.expiration
 
-                if default_role == profile:
-                    logging.info("default role: {} until {}".format(profile, expires_utc))
+                if default_profile == profile:
+                    logging.info("default profile: {} until {}".format(profile, expires_utc))
                 else:
-                    logging.info("role: {} until {}".format(profile, expires_utc))
+                    logging.info("profile: {} until {}".format(profile, expires_utc))
 
     def _bind_assertion_to_role(self, assertion, role, profile, region,
-                                credentials_filename, config_filename, default_role):
+                                credentials_filename, config_filename, default_profile):
         """
         Attempts to assume an IAM role using a given SAML assertion.
         :param assertion: A SAML assertion authenticating the user
@@ -193,7 +194,7 @@ class KerberosHandler:
         :param region: The region the role is being assumed in
         :param credentials_filename: Output file for the regions/formats for each profile
         :param config_filename: Output file for the generated tokens
-        :param default_role: Which role should be set as default in the config
+        :param default_profile: Which profile should be set as default in the config
         :return token: A valid token with temporary IAM credentials
         """
 
@@ -215,10 +216,10 @@ class KerberosHandler:
         config = configparser.RawConfigParser(default_section=default_section)
         config.read(config_filename)
 
-        # If the default_role was passed in on the command line we will overwrite
+        # If the default_profile was passed in on the command line we will overwrite
         # the [default] section of the credentials file
         sections = []
-        if default_role == profile:
+        if default_profile == profile:
             sections.append(default_section)
 
         # Make sure the section exists

--- a/tests/test_awsrole.py
+++ b/tests/test_awsrole.py
@@ -17,38 +17,28 @@ from kerb_sts.awsrole import AWSRole
 
 
 class TestAWSRoleCreation(unittest.TestCase):
-    def test_with_role_as_none(self):
-        is_valid = AWSRole.is_valid(None)
-        self.assertFalse(is_valid)
+    def test_with_none(self):
+        self.assertRaises(ValueError, AWSRole, None)
 
     def test_with_empty_string(self):
-        is_valid = AWSRole.is_valid('')
-        self.assertFalse(is_valid)
+        self.assertRaises(ValueError, AWSRole, '')
 
-    def test_with_malformed_role_string(self):
-        is_valid = AWSRole.is_valid('arn_noseparator_provider')
-        self.assertFalse(is_valid)
+    def test_with_malformed_string(self):
+        self.assertRaises(ValueError, AWSRole, 'arn_noseparator_provider')
 
     def test_with_missing_arn_string(self):
-        is_valid = AWSRole.is_valid(',provider')
-        self.assertFalse(is_valid)
+        self.assertRaises(ValueError, AWSRole, ',provider')
 
     def test_with_missing_provider_string(self):
-        is_valid = AWSRole.is_valid('arn/role,')
-        self.assertFalse(is_valid)
+        self.assertRaises(ValueError, AWSRole, 'arn:aws:iam::123456789012:role/path/role-name,')
 
-    def test_with_valid_strings(self):
-        is_valid = AWSRole.is_valid('arn/role,provider')
-        self.assertTrue(is_valid)
-
-    def test_parsed_role(self):
-        role = AWSRole('arn/role,provider')
-        self.assertEqual(role.arn, 'arn/role')
+    def test_with_well_formed_string(self):
+        role = AWSRole('arn:aws:iam::123456789012:role/path/role-name,provider')
+        self.assertEqual(role.account, '123456789012')
+        self.assertEqual(role.arn, 'arn:aws:iam::123456789012:role/path/role-name')
+        self.assertEqual(role.name, 'role-name')
+        self.assertEqual(role.profile, '123456789012.role-name')
         self.assertEqual(role.provider, 'provider')
-
-    def test_with_valid_strings(self):
-        role = AWSRole('arn/role,provider')
-        self.assertEqual(role.name, 'role')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If we detect a form going to onelogin.com, extract a token from it
and post it to the URL provided. This should result in a SAML
assertion exactly like from ADFS.
