### PR TITLE
Handle multiple AWS accounts

### DIFF
--- a/kerb_sts/__main__.py
+++ b/kerb_sts/__main__.py
@@ -65,8 +65,8 @@ def _get_options():
                         dest='configure', action='store_true', default=False)
     parser.add_argument('--daemon', help="Run as a daemon. This will auto-renew credentials every half hour",
                         dest='daemon', action='store_true', default=False)
-    parser.add_argument('-r', '--default_role', help="Name of the Role to use as the default",
-                        dest='default_role', default=None)
+    parser.add_argument('-r', '--default_profile', help="Name of the Profile to use as the default",
+                        dest='default_profile', default=None)
     parser.add_argument('-d', '--domain', help="AD Domain if using a Kerberos keytab or NTLM auth. Requires a username and password/keytab",
                         dest='domain', default=None)
     parser.add_argument('--keytab', help="The Kerberos keytab file. Requires a username and domain",
@@ -204,13 +204,13 @@ def _generate_tokens(options, config, authenticator):
     logging.info("region: {}".format(config.region))
     logging.info("url: {}".format(config.idp_url))
     logging.info("credentials file: {}".format(options.credentials_file))
-    if options.default_role:
-        logging.info("default role: {}".format(options.default_role))
+    if options.default_profile:
+        logging.info("default profile: {}".format(options.default_profile))
     logging.info("auth type: {}".format(authenticator.get_auth_type()))
 
     h = KerberosHandler()
     h.handle_sts_by_kerberos(config.region, config.idp_url, options.credentials_file, options.config_file,
-                             options.default_role, options.list, authenticator)
+                             options.default_profile, options.list, authenticator)
     logging.info("--------------------------------")
 
 

--- a/tests/test_awsrole.py
+++ b/tests/test_awsrole.py
@@ -17,38 +17,28 @@ from kerb_sts.awsrole import AWSRole
 
 
 class TestAWSRoleCreation(unittest.TestCase):
-    def test_with_role_as_none(self):
-        is_valid = AWSRole.is_valid(None)
-        self.assertFalse(is_valid)
+    def test_with_none(self):
+        self.assertRaises(ValueError, AWSRole, None)
 
     def test_with_empty_string(self):
-        is_valid = AWSRole.is_valid('')
-        self.assertFalse(is_valid)
+        self.assertRaises(ValueError, AWSRole, '')
 
-    def test_with_malformed_role_string(self):
-        is_valid = AWSRole.is_valid('arn_noseparator_provider')
-        self.assertFalse(is_valid)
+    def test_with_malformed_string(self):
+        self.assertRaises(ValueError, AWSRole, 'arn_noseparator_provider')
 
     def test_with_missing_arn_string(self):
-        is_valid = AWSRole.is_valid(',provider')
-        self.assertFalse(is_valid)
+        self.assertRaises(ValueError, AWSRole, ',provider')
 
     def test_with_missing_provider_string(self):
-        is_valid = AWSRole.is_valid('arn/role,')
-        self.assertFalse(is_valid)
+        self.assertRaises(ValueError, AWSRole, 'arn:aws:iam::123456789012:role/path/role-name,')
 
-    def test_with_valid_strings(self):
-        is_valid = AWSRole.is_valid('arn/role,provider')
-        self.assertTrue(is_valid)
-
-    def test_parsed_role(self):
-        role = AWSRole('arn/role,provider')
-        self.assertEqual(role.arn, 'arn/role')
+    def test_with_well_formed_string(self):
+        role = AWSRole('arn:aws:iam::123456789012:role/path/role-name,provider')
+        self.assertEqual(role.account, '123456789012')
+        self.assertEqual(role.arn, 'arn:aws:iam::123456789012:role/path/role-name')
+        self.assertEqual(role.name, 'role-name')
+        self.assertEqual(role.profile, '123456789012.role-name')
         self.assertEqual(role.provider, 'provider')
-
-    def test_with_valid_strings(self):
-        role = AWSRole('arn/role,provider')
-        self.assertEqual(role.name, 'role')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Name profile entries `account-id`.`role-name` so that when a user has access to multiple AWS accounts through identically named roles, they all get written to the config and credentials files.

Merge `_parse()` and `is_valid()` in the AWSRole class to avoid duplicate code. Fix role ARN parsing to handle roles that have a path other than root ('/').

Rename the `--default_role` switch to `--default_profile` to clarify that a profile is more than just a role name.

Stop looping through `<input>` tags once a SAMLResponse has been found.