### PR TITLE
Add --only_role option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AWS KERBEROS STS
-Based on the ADSF-CLI script [originally posted by Quint Van Deman](https://blogs.aws.amazon.com/security/post/Tx1LDN0UBGJJ26Q/How-to-Implement-Federated-API-and-CLI-Access-Using-SAML-2-0-and-AD-FS).
+Based on the ADFS-CLI script [originally posted by Quint Van Deman](https://blogs.aws.amazon.com/security/post/Tx1LDN0UBGJJ26Q/How-to-Implement-Federated-API-and-CLI-Access-Using-SAML-2-0-and-AD-FS).
 
 ## Overview
 This script provides a seamless mechanism for federating the AWS CLI. When properly configured, this script allows a user to get a short lived (1 hour) set of credentials for each authorized role.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ Users can then leverage the default role or use the AWS_DEFAULT_PROFILE environm
 select a specific role/profile. You can find more information about the credentials file
 in the [AWS Documentation](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files).
 
+#### Only Role
+If you have a lot of roles available, it may take a while to process all available roles.
+In this case, you can use the `-o` option and only the specified role will be processed.
+It will also be treated as the default role (`-r` option).
+
 #### Daemon
 By passing in a `--daemon` flag, the script will continue running and update the credentials file every
 half hour. The refresh time can be set with the `--refresh` argument, but remember

--- a/kerb_sts/__main__.py
+++ b/kerb_sts/__main__.py
@@ -67,6 +67,8 @@ def _get_options():
                         dest='daemon', action='store_true', default=False)
     parser.add_argument('-r', '--default_role', help="Name of the Role to use as the default",
                         dest='default_role', default=None)
+    parser.add_argument('-o', '--only_role', help="Name of the Role to use as the default (no other roles will be processed)",
+                        dest='only_role', default=None)
     parser.add_argument('-d', '--domain', help="AD Domain if using a Kerberos keytab or NTLM auth. Requires a username and password/keytab",
                         dest='domain', default=None)
     parser.add_argument('--keytab', help="The Kerberos keytab file. Requires a username and domain",
@@ -205,13 +207,16 @@ def _generate_tokens(options, config, authenticator):
     logging.info("region: {}".format(config.region))
     logging.info("url: {}".format(config.idp_url))
     logging.info("credentials file: {}".format(options.credentials_file))
-    if options.default_role:
+    if options.only_role:
+        logging.info("only role: {}".format(options.only_role))
+        options.default_role = options.only_role
+    elif options.default_role:
         logging.info("default role: {}".format(options.default_role))
     logging.info("auth type: {}".format(authenticator.get_auth_type()))
 
     h = KerberosHandler()
     h.handle_sts_by_kerberos(config.region, config.idp_url, options.credentials_file, options.config_file,
-                             options.default_role, options.list, authenticator)
+                             options.only_role, options.default_role, options.list, authenticator)
     logging.info("--------------------------------")
 
 


### PR DESCRIPTION
This makes it so that, when specified, only the specified role is processed, and it is treated as the default role.

This improves performance dramatically when a user has lots of roles available.